### PR TITLE
Finish writing out 'phpunit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make test
 git clone git@github.com:lmuzinic/phplonghorn-pragmatic-tdd.git
 cd phplonghorn-pragmatic-tdd/app
 composer install
-vendor/bin/php
+vendor/bin/phpunit
 ```
      
 #### Verify that everything works


### PR DESCRIPTION
Since the `make` instructions and the `composer` instructions should
lead to the same conclusion, ensure that both finish with running
phpunit